### PR TITLE
windows compatibility and lzma

### DIFF
--- a/notebooks/gnps_bilelib.ipynb
+++ b/notebooks/gnps_bilelib.ipynb
@@ -2,29 +2,54 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "2d058e45",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
+    "import pathlib\n",
     "import sys\n",
     "# Make sure all code is in the PATH.\n",
-    "sys.path.append(\n",
-    "    os.path.normpath(\n",
-    "        os.path.join(\n",
-    "            os.environ[\"HOME\"], \"Projects\", \"cosine_neutral_loss\", \"src\"\n",
+    "try:\n",
+    "    sys.path.append(\"../src\")\n",
+    "except:\n",
+    "    pass\n",
+    "try:\n",
+    "    sys.path.append(\n",
+    "        os.path.normpath(\n",
+    "            os.path.join(\n",
+    "                os.environ[\"HOME\"], \"Projects\", \"cosine_neutral_loss\", \"src\"\n",
+    "            )\n",
     "        )\n",
     "    )\n",
-    ")"
+    "except:\n",
+    "    pass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "818f0dd9",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\Robin\\AppData\\Local\\Temp\\ipykernel_19364\\1304967379.py:16: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import functools\n",
     "import lzma\n",
@@ -52,9 +77,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "05c3d71a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Plot styling.\n",
@@ -67,16 +96,24 @@
   {
    "cell_type": "markdown",
    "id": "575d2f8e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Analysis settings"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "cb2e8e92",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Spectra and spectrum pairs to include with the following settings.\n",
@@ -89,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "aeed67b4",
    "metadata": {
     "pycharm": {
@@ -145,7 +182,11 @@
   {
    "cell_type": "markdown",
    "id": "f7e3f7c2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Data IO"
    ]
@@ -153,9 +194,49 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6eed4a0",
-   "metadata": {},
    "outputs": [],
+   "source": [
+    "filename_text = (\"../data/external/BILELIB19.mgf\")\n",
+    "filename = (\"../data/external/BILELIB19.mgf.xz\")\n",
+    "if not pathlib.Path(filename).exists():\n",
+    "    with open(filename_text, \"rt\") as file:\n",
+    "        with lzma.open(filename, \"wt\") as out:\n",
+    "            for line in file:\n",
+    "                out.write(line)\n",
+    "    print(\"exported compressed file\")\n",
+    "else: print(\"compressed file already available\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n",
+     "is_executing": true
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d6eed4a0",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "0it [00:00, ?it/s]",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "67a229eb73c841c48d54c446c9b17c4f"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Read all spectra from the MGF.\n",
     "# BILELIB19 (retrieved on 2022-05-12) downloaded from\n",
@@ -199,9 +280,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "b55b5a79",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extract the metadata (library identifier and precursor charge and m/z).\n",
@@ -227,16 +312,24 @@
   {
    "cell_type": "markdown",
    "id": "c1730111",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Compute spectrum-spectrum similarities"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "8bc8cbfd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extract indexes for the relevant pairs of spectra.\n",
@@ -269,8 +362,26 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3b37595c",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n",
+     "is_executing": true
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "  0%|          | 0/340637 [00:00<?, ?it/s]",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "bb404686e8d14f56a8d240bbaaba1c7a"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Compute similarities between spectrum pairs.\n",
     "scores = []\n",
@@ -317,7 +428,11 @@
   {
    "cell_type": "markdown",
    "id": "4fc1795d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Results plotting"
    ]
@@ -326,7 +441,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d1792fa7",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "similarities[\"abs_mz_diff\"] = (\n",
@@ -340,7 +459,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0fba26b4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "oxygen = 15.994915\n",
@@ -353,7 +476,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "71d5b361",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "conjugations = {\n",
@@ -378,7 +505,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9ea6af1f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "substitutions = {\n",
@@ -406,7 +537,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "99ef5567",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "similarities[\"tanimoto_interval\"] = pd.cut(\n",
@@ -425,7 +560,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "335d06a2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "print(f\"Number of spectrum pairs: {len(similarities):,}\")\n",
@@ -446,7 +585,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "62bb3004",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "mosaic = \"\"\"\n",

--- a/notebooks/gnps_libraries.ipynb
+++ b/notebooks/gnps_libraries.ipynb
@@ -2,32 +2,57 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "2d058e45",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
     "# Make sure all code is in the PATH.\n",
-    "sys.path.append(\n",
-    "    os.path.normpath(\n",
-    "        os.path.join(\n",
-    "            os.environ[\"HOME\"], \"Projects\", \"cosine_neutral_loss\", \"src\"\n",
+    "try:\n",
+    "    sys.path.append(\"../src\")\n",
+    "except:\n",
+    "    pass\n",
+    "try:\n",
+    "    sys.path.append(\n",
+    "        os.path.normpath(\n",
+    "            os.path.join(\n",
+    "                os.environ[\"HOME\"], \"Projects\", \"cosine_neutral_loss\", \"src\"\n",
+    "            )\n",
     "        )\n",
     "    )\n",
-    ")"
+    "except:\n",
+    "    pass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "818f0dd9",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\Robin\\AppData\\Local\\Temp\\ipykernel_2212\\113710871.py:17: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import functools\n",
     "import lzma\n",
+    "import pathlib\n",
     "import re\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -52,9 +77,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "05c3d71a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Plot styling.\n",
@@ -67,16 +96,24 @@
   {
    "cell_type": "markdown",
    "id": "575d2f8e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Analysis settings"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "cb2e8e92",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Spectra and spectrum pairs to include with the following settings.\n",
@@ -89,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "aeed67b4",
    "metadata": {
     "pycharm": {
@@ -145,7 +182,11 @@
   {
    "cell_type": "markdown",
    "id": "f7e3f7c2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Data IO"
    ]
@@ -153,8 +194,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "0it [00:00, ?it/s]",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "b6c83d89910849039cfaf911ca74aa14"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "filename_text = (\"../data/external/ALL_GNPS_NO_PROPOGATED.mgf\")\n",
+    "filename = (\"../data/external/ALL_GNPS_NO_PROPOGATED.mgf.xz\")\n",
+    "if not pathlib.Path(filename).exists():\n",
+    "    with open(filename_text, \"rt\") as file:\n",
+    "        with lzma.open(filename, \"wt\") as out:\n",
+    "            for line in tqdm(file):\n",
+    "                out.write(line)\n",
+    "    print(\"exported compressed file\")\n",
+    "else: print(\"compressed file already available\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n",
+     "is_executing": true
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "d6eed4a0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Read all spectra from the MGF.\n",
@@ -201,7 +282,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b55b5a79",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extract the metadata (library identifier and precursor charge and m/z).\n",
@@ -227,7 +312,11 @@
   {
    "cell_type": "markdown",
    "id": "c1730111",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Compute spectrum-spectrum similarities"
    ]
@@ -236,7 +325,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8bc8cbfd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extract indexes for the relevant pairs of spectra.\n",
@@ -269,7 +362,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c1c5e11e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Randomly subsample the pairs so it remains computationally tractable.\n",
@@ -281,7 +378,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3b37595c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Compute similarities between spectrum pairs.\n",
@@ -329,7 +430,11 @@
   {
    "cell_type": "markdown",
    "id": "4fc1795d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Results plotting"
    ]
@@ -338,7 +443,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "99ef5567",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "similarities[\"tanimoto_interval\"] = pd.cut(\n",
@@ -357,7 +466,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "335d06a2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "print(f\"Number of spectrum pairs: {len(similarities):,}\")\n",
@@ -375,7 +488,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "62bb3004",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "mosaic = \"\"\"\n",
@@ -615,7 +732,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "947dc4ae",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "similarities_filtered = similarities[similarities[\"tanimoto\"] > 0.9]\n",

--- a/notebooks/massivekb_peptide_mods.ipynb
+++ b/notebooks/massivekb_peptide_mods.ipynb
@@ -4,26 +4,41 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2d058e45",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
     "# Make sure all code is in the PATH.\n",
-    "sys.path.append(\n",
-    "    os.path.normpath(\n",
-    "        os.path.join(\n",
-    "            os.environ[\"HOME\"], \"Projects\", \"cosine_neutral_loss\", \"src\"\n",
+    "try:\n",
+    "    sys.path.append(\"../src\")\n",
+    "except:\n",
+    "    pass\n",
+    "try:\n",
+    "    sys.path.append(\n",
+    "        os.path.normpath(\n",
+    "            os.path.join(\n",
+    "                os.environ[\"HOME\"], \"Projects\", \"cosine_neutral_loss\", \"src\"\n",
+    "            )\n",
     "        )\n",
     "    )\n",
-    ")"
+    "except:\n",
+    "    pass"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "818f0dd9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import functools\n",
@@ -50,7 +65,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "05c3d71a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Plot styling.\n",
@@ -63,7 +82,11 @@
   {
    "cell_type": "markdown",
    "id": "bece364c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Analysis settings"
    ]
@@ -72,7 +95,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e751f381",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Spectra and spectrum pairs to include with the following settings.\n",
@@ -85,7 +112,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e1fe37eb",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "regex_non_alpha = re.compile(r\"[^A-Za-z]+\")\n",
@@ -123,7 +154,11 @@
   {
    "cell_type": "markdown",
    "id": "9798c07e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Data IO"
    ]
@@ -132,7 +167,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d6eed4a0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Read all spectra from the MGF.\n",
@@ -160,7 +199,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5cfaca5d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extract the metadata (peptide sequence and precursor charge and m/z).\n",
@@ -178,7 +221,11 @@
   {
    "cell_type": "markdown",
    "id": "25cc3029",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Compute spectrum-spectrum similarities"
    ]
@@ -187,7 +234,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "50302807",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extract indexes for pairs of spectra whose peptides differ by a\n",
@@ -234,7 +285,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "23c8cf55",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Compute similarities between spectrum pairs.\n",
@@ -291,7 +346,11 @@
   {
    "cell_type": "markdown",
    "id": "e6634f23",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Results plotting"
    ]
@@ -300,7 +359,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a8cdf414",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "similarities[\"mod_interval\"] = pd.cut(\n",
@@ -319,7 +382,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2ff656ba",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "print(f\"Number of spectrum pairs: {len(similarities):,}\")\n",
@@ -340,7 +407,10 @@
    "metadata": {
     "code_folding": [
      0
-    ]
+    ],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -463,7 +533,10 @@
    "metadata": {
     "code_folding": [
      0
-    ]
+    ],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -583,7 +656,10 @@
    "metadata": {
     "code_folding": [
      0
-    ]
+    ],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -629,7 +705,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7bd1f470",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "mosaic = \"\"\"\n",


### PR DESCRIPTION
I forgot to do this PR earlier. To enhance to compativility it might be nice to include a relative path instead of the unix specific ones. At least for windows then it works out of the box. 

Also the files on zenodo are not compressed and I think it would be good to include the compression here or not rely on the files being compressed at all - just so that all people can use it without compressing the files manually. What do you think?